### PR TITLE
Fix trailing slash problem.

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,7 +19,6 @@ import styles from 'highlight.js/styles/vs2015.css';
 import ourStyles from "~/styles/styles.css";
 import bscImage from "./assets/blacksheep_fb_wide.webp";
 import { GithubPermalinkProvider } from "react-github-permalink";
-import { isErrorResponse } from "@remix-run/react/dist/data";
 import { Page404 } from "./error_pages/Page404";
 import { Page500 } from "./error_pages/Page500";
 

--- a/app/utils/blogPosts.tsx
+++ b/app/utils/blogPosts.tsx
@@ -71,9 +71,9 @@ export function createLoaderFunction(folder: BlogPostFolders): LoaderFunction {
         // Unfortunately we don't have access to the path via loader args, so we have to manually extract
         // it from the request. 
         const url = loaderArgs.request.url;
-        const parts = url.split('/');
-        const desiredPart = ["", parts[parts.length - 2], parts[parts.length - 1]].join("/"); 
-        return getFrontmatterFromSlug(desiredPart)
+
+        const path = new URL(url).pathname; 
+        return getFrontmatterFromSlug(path)
     }
 }
 

--- a/cypress/e2e/smoketests.cy.ts
+++ b/cypress/e2e/smoketests.cy.ts
@@ -67,4 +67,18 @@ describe('Test pages', () => {
 
     }
     )
+
+    it("trailing slash doesn't matter", () => {
+      cy.visit('test/basic_mdx/'); 
+
+      cy.findByRole("heading", {name: "This is a basic MDX test."}).should("exist");
+      cy.findByText("This is some text").should("exist");
+    })
+
+    it("query params - won't break things", () => {
+      cy.visit('test/basic_mdx?q=foo'); 
+
+      cy.findByRole("heading", {name: "This is a basic MDX test."}).should("exist");
+      cy.findByText("This is some text").should("exist");
+    })
 })


### PR DESCRIPTION
Urls like `https://blacksheepcode.com/posts/foo/` with a trailing slash were causing 500 errors. This fixes that. 