### PR TITLE
Add cache header.

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -128,6 +128,7 @@ function handleBrowserRequest(
           const body = new PassThrough();
 
           responseHeaders.set("Content-Type", "text/html");
+          responseHeaders.set("Cache-Control", `public, max-age=${60*60*24}`);
 
           resolve(
             new Response(body, {


### PR DESCRIPTION
Adds cache headers to our SSR pages. Valid one day. It means that users may see out of date content for one day, I think we're ok with that. 